### PR TITLE
Remove bottle :unneeded as it's deprecated

### DIFF
--- a/ecs-service-logs.rb
+++ b/ecs-service-logs.rb
@@ -3,7 +3,6 @@ class EcsServiceLogs < Formula
   desc "ecs-service-logs is used to filter JSON-formatted log lines in CloudWatch."
   homepage "https://github.com/trussworks/ecs-service-logs"
   version "0.3.0"
-  bottle :unneeded
 
   if OS.mac?
     url "https://github.com/trussworks/ecs-service-logs/releases/download/v0.3.0/ecs-service-logs_0.3.0_Darwin_x86_64.tar.gz"

--- a/find-guardduty-user.rb
+++ b/find-guardduty-user.rb
@@ -3,7 +3,6 @@ class FindGuarddutyUser < Formula
   desc "find-guardduty-user is used to search CloudTrial to find users that triggered GuardDuty alerts."
   homepage "https://github.com/trussworks/find-guardduty-user"
   version "0.0.3"
-  bottle :unneeded
 
   if OS.mac?
     url "https://github.com/trussworks/find-guardduty-user/releases/download/v0.0.3/find-guardduty-user_0.0.3_Darwin_x86_64.tar.gz"

--- a/health-checker.rb
+++ b/health-checker.rb
@@ -3,7 +3,6 @@ class HealthChecker < Formula
   desc "health-checker is used to verity that websites are healthy following a deploy."
   homepage "https://github.com/trussworks/health-checker"
   version "0.0.0"
-  bottle :unneeded
 
   if OS.mac?
     url "https://github.com/trussworks/health-checker/releases/download/v0.0.0/health-checker_0.0.0_Darwin_x86_64.tar.gz"

--- a/setup-new-aws-user.rb
+++ b/setup-new-aws-user.rb
@@ -3,7 +3,6 @@ class SetupNewAwsUser < Formula
   desc "A tool that creates a virtual MFA device and rotates access keys for a new AWS user."
   homepage "https://github.com/trussworks/setup-new-aws-user"
   version "0.5.2"
-  bottle :unneeded
 
   if OS.mac?
     url "https://github.com/trussworks/setup-new-aws-user/releases/download/v0.5.2/setup-new-aws-user_0.5.2_Darwin_x86_64.tar.gz"

--- a/tls-checker.rb
+++ b/tls-checker.rb
@@ -3,7 +3,6 @@ class TlsChecker < Formula
   desc "tls-checker is used to verify that websites are serving on accepted TLS versions and not downgrading."
   homepage "https://github.com/trussworks/tls-checker"
   version "0.0.2"
-  bottle :unneeded
 
   if OS.mac?
     url "https://github.com/trussworks/tls-checker/releases/download/v0.0.2/tls-checker_0.0.2_Darwin_x86_64.tar.gz"


### PR DESCRIPTION
I finally got tired of seeing the following when I run `brew update` so I fixed it. To test changes I believe you need to put the files in `/path/to/brew/repo/Library/Taps/trussworks/homebrew-tap`. Find your `/path/to/brew/repo` by running `brew --repo`

```
Warning: Calling bottle :unneeded is deprecated! There is no replacement.
Please report this issue to the trussworks/tap tap (not Homebrew/brew or Homebrew/core):
  /opt/homebrew/Library/Taps/trussworks/homebrew-tap/setup-new-aws-user.rb:6
```